### PR TITLE
last update

### DIFF
--- a/TankPres_2.py
+++ b/TankPres_2.py
@@ -141,7 +141,7 @@ A_Tube = pi/4*(D_Tube**2);      # Tube area [m2]
 Q_He_Ox = Q_LOx;                 # Volumetric flow of Helium in tank [m3/s]
 v_He_Ox = Q_He_Ox/A_t;          # Helium plane velocity [m/s]
 
-P_0 = 1314.7*psi2pa;            # Helium Pressure in Tank [Pa]
+P_0 = 2214.7*psi2pa;            # Helium Pressure in Tank [Pa]
 T_0 = 310;                      # Helium Temperature in tank at desert [K]
 
 P_T_LOx = PT_LOx*psi2pa;          # Required Prop Tank Pressure [Pa]
@@ -149,19 +149,40 @@ P_T_LOx = PT_LOx*psi2pa;          # Required Prop Tank Pressure [Pa]
 p_He_Tank = P_0/R_He/T_0/Z_0;   # Density of Helium leaving tank [kg/m3]
 
 N2 = 22.67;     # numerical constant (std ft3/min, psia,R)
-p1 = 1314.7;    # absolute pressure
-p11 = 564.7;    
-p2  = 465+14.7;
-dp = p11-p2;
+p1 = 2214.7;    # absolute pressure
+pox = 554.7;    
+pch4  = 460+14.7;
+dp_ox = p1-pox;
+dp_ch4 = p1 - pch4;
 Gg = .138;      # gas specific gravity
 T_R = 558;      # inlet temp Rankine
 T_Std = 273.15; # standard temp [K]
 P_Std = 101325; # standard pressure [Pa]
-actual_ft = Q_He_Ox*m3s2ft3min;             # flow rate req in ft3/min
-q_ft = actual_ft*(P_0/P_Std)*(T_Std/T_0); 	# flow rate in std ft3/min
 
-Cv_sonic = (q_ft/(0.471*N2*p1))*sqrt(Gg*T_R);
+# oxygen side
+Q_He_Ox = 0.7898/1000;
+actual_ft_ox = Q_He_Ox*m3s2ft3min;             # flow rate req in ft3/min
+q_ft_ox = actual_ft_ox*(pox*psi2pa/P_Std)*(T_Std/T_0); 	# flow rate in std ft3/min
+Cv_sonic_ox = (q_ft_ox/(0.471*N2*p1))*sqrt(Gg*T_R);  # cv at sonic flow
+nitrogen_scfm_ox = q_ft_ox/2.65;
 
-q_act_ch4 = Q_CH4*m3s2ft3min;
-q_ft_ch4 = q_act_ch4*(p11*psi2pa/P_Std)*(T_Std/T_0);
-Cv_sub = (q_ft_ch4/(N2*p11*(1-(2*dp/(3*p11)))))*sqrt(Gg*p11*T_R/dp);
+# methane side
+Q_CH4 = 0.75906/1000;
+q_act_ch4 = Q_CH4*m3s2ft3min;       # actual flow rate
+q_ft_ch4 = q_act_ch4*(pch4*psi2pa/P_Std)*(T_Std/T_0);   # flow rate in scfm
+Cv_sonic_ch4 = (q_ft_ch4/(0.471*N2*p1))*sqrt(Gg*T_R);# cv at sonic flow
+nitrogen_scfm_ch4 = q_ft_ch4/2.65;
+
+print(' ') 
+print('Helium LOX SIDE paramters')
+print('flow rate of helium',float(actual_ft_ox),'ft3/min')
+print('flow rate of helium in SCFM',float(q_ft_ox),'ft3/min')
+print('Cv at choked flow',float(Cv_sonic_ox))
+print('equivalent flow rate of nitrogen in SCFM',float(nitrogen_scfm_ox),'ft3/min')
+
+print(' ') 
+print('Helium CH4 SIDE paramters')
+print('flow rate of helium',float(q_act_ch4),'ft3/min')
+print('flow rate of helium in SCFM',float(q_ft_ch4),'ft3/min')
+print('Cv at choked flow',float(Cv_sonic_ch4))
+print('equivalent flow rate of nitrogen in SCFM',float(nitrogen_scfm_ch4),'ft3/min')


### PR DESCRIPTION
lots of small fixes on the section (regulator setting):

there will be no pressure drop that meets the condition P1 < 2*P2 so the flow condition is always choked -- no sub sonic flow
so this equation does not apply:
Cv_sub_ox = (q_ft_ox/(N2*p1*(1-(2*dp_ox/(3*p1)))))*sqrt(Gg*p1*T_R/dp_ox);

in calculating scfm for oxygen, the helium tank pressure was used instead of the oxygen tank pressure 

i added a conversion to nitrogen scfm for easier reference to flow curves on swageloks

I used the volumetric flow rates founc by this document:
https://docs.google.com/spreadsheets/d/1cXLcPzspb9ZbnEzCvEGgvpn0GadbOhYLLah2myHksWk/edit#gid=1173199380
 (its basically the same value as ones calculated previously, I checked it to make sure)

after changes, you should see that flow rates, in nitrogen equivalent scfm as well as CV values, will not be a problem for the previously sourced pressure regulators. But the relief values may need to be changed due to higher pressure drop 2200 to 540 & 460

CV for oxygen side 0.02
CV for methance side 0.017

equivalent nitrogen scfm flow rate
oxygen side 21 scfm
methane side 17.3 scfm